### PR TITLE
Ignore pre-commit hooks for the commit stage

### DIFF
--- a/bin/git-directory-deploy.sh
+++ b/bin/git-directory-deploy.sh
@@ -148,7 +148,7 @@ case $diff in
     0) echo No changes to files in $deploy_directory. Skipping commit.;;
     1)
         set_user_id
-        git --work-tree "$deploy_directory" commit -m \
+        git --work-tree "$deploy_directory" commit -nm \
             "publish: $commit_title$append_message"$'\n\n'"generated from commit $commit_hash"
 
         disable_expanded_output


### PR DESCRIPTION
Typically pre-commit hooks are used for small pre-flight checks on the source code, such as linting or tests. Generally these don't/wont apply for the website. Some setups will fail given the `--work-tree` option - expecting scripts or files to exist where they don't inside the work tree.

This change disables pre-commit hook validation for the commit stage, so that any potential failures are ignored.
